### PR TITLE
feat: #2 SVGパースのプリミティブ抽出基盤

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ name = "blueprinter"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "roxmltree",
 ]
 
 [[package]]
@@ -140,6 +141,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.78.0"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+roxmltree = "0.20"
 
 [dev-dependencies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod svg;

--- a/src/svg/mod.rs
+++ b/src/svg/mod.rs
@@ -1,0 +1,5 @@
+pub mod parser;
+pub mod primitive;
+
+pub use parser::parse_svg;
+pub use primitive::Primitive;

--- a/src/svg/parser.rs
+++ b/src/svg/parser.rs
@@ -1,0 +1,130 @@
+use roxmltree::{Document, Node};
+
+use crate::svg::primitive::Primitive;
+
+#[derive(Debug, PartialEq)]
+pub enum ParseError {
+    XmlParseError(String),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::XmlParseError(msg) => write!(f, "XML parse error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+pub fn parse_svg(input: &str) -> Result<Vec<Primitive>, ParseError> {
+    let doc = Document::parse(input).map_err(|e| ParseError::XmlParseError(e.to_string()))?;
+    let root = doc.root_element();
+    parse_children(&root)
+}
+
+fn parse_children(node: &Node<'_, '_>) -> Result<Vec<Primitive>, ParseError> {
+    let mut primitives = Vec::new();
+    for child in node.children().filter(|n| n.is_element()) {
+        primitives.push(parse_element(&child)?);
+    }
+    Ok(primitives)
+}
+
+fn parse_element(node: &Node<'_, '_>) -> Result<Primitive, ParseError> {
+    let tag = node.tag_name().name();
+    match tag {
+        "rect" => Ok(Primitive::Rect {
+            x: attr_f64(node, "x").unwrap_or(0.0),
+            y: attr_f64(node, "y").unwrap_or(0.0),
+            width: attr_f64(node, "width").unwrap_or(0.0),
+            height: attr_f64(node, "height").unwrap_or(0.0),
+            fill: attr_string(node, "fill"),
+            stroke: attr_string(node, "stroke"),
+            stroke_width: attr_f64(node, "stroke-width"),
+        }),
+        "line" => Ok(Primitive::Line {
+            x1: attr_f64(node, "x1").unwrap_or(0.0),
+            y1: attr_f64(node, "y1").unwrap_or(0.0),
+            x2: attr_f64(node, "x2").unwrap_or(0.0),
+            y2: attr_f64(node, "y2").unwrap_or(0.0),
+            stroke: attr_string(node, "stroke"),
+            stroke_width: attr_f64(node, "stroke-width"),
+        }),
+        "polyline" => Ok(Primitive::Polyline {
+            points: parse_points(node.attribute("points").unwrap_or("")),
+            stroke: attr_string(node, "stroke"),
+            stroke_width: attr_f64(node, "stroke-width"),
+        }),
+        "path" => Ok(Primitive::Path {
+            d: attr_string(node, "d").unwrap_or_default(),
+            fill: attr_string(node, "fill"),
+            stroke: attr_string(node, "stroke"),
+            stroke_width: attr_f64(node, "stroke-width"),
+        }),
+        "circle" => Ok(Primitive::Circle {
+            cx: attr_f64(node, "cx").unwrap_or(0.0),
+            cy: attr_f64(node, "cy").unwrap_or(0.0),
+            r: attr_f64(node, "r").unwrap_or(0.0),
+            fill: attr_string(node, "fill"),
+            stroke: attr_string(node, "stroke"),
+            stroke_width: attr_f64(node, "stroke-width"),
+        }),
+        "ellipse" => Ok(Primitive::Ellipse {
+            cx: attr_f64(node, "cx").unwrap_or(0.0),
+            cy: attr_f64(node, "cy").unwrap_or(0.0),
+            rx: attr_f64(node, "rx").unwrap_or(0.0),
+            ry: attr_f64(node, "ry").unwrap_or(0.0),
+            fill: attr_string(node, "fill"),
+            stroke: attr_string(node, "stroke"),
+            stroke_width: attr_f64(node, "stroke-width"),
+        }),
+        "polygon" => Ok(Primitive::Polygon {
+            points: parse_points(node.attribute("points").unwrap_or("")),
+            fill: attr_string(node, "fill"),
+            stroke: attr_string(node, "stroke"),
+            stroke_width: attr_f64(node, "stroke-width"),
+        }),
+        "text" => Ok(Primitive::Text {
+            x: attr_f64(node, "x").unwrap_or(0.0),
+            y: attr_f64(node, "y").unwrap_or(0.0),
+            content: node
+                .children()
+                .filter_map(|n| n.text())
+                .collect::<Vec<_>>()
+                .concat(),
+            font_family: attr_string(node, "font-family"),
+            font_size: attr_f64(node, "font-size"),
+            fill: attr_string(node, "fill"),
+        }),
+        "g" => Ok(Primitive::Group {
+            children: parse_children(node)?,
+        }),
+        _ => Ok(Primitive::Unknown {
+            tag: tag.to_string(),
+            attrs: node
+                .attributes()
+                .map(|a| (a.name().to_string(), a.value().to_string()))
+                .collect(),
+        }),
+    }
+}
+
+fn attr_f64(node: &Node<'_, '_>, name: &str) -> Option<f64> {
+    node.attribute(name)?.parse::<f64>().ok()
+}
+
+fn attr_string(node: &Node<'_, '_>, name: &str) -> Option<String> {
+    Some(node.attribute(name)?.to_string())
+}
+
+fn parse_points(s: &str) -> Vec<(f64, f64)> {
+    s.split_whitespace()
+        .filter_map(|pair| {
+            let mut parts = pair.split(',');
+            let x = parts.next()?.parse::<f64>().ok()?;
+            let y = parts.next()?.parse::<f64>().ok()?;
+            Some((x, y))
+        })
+        .collect()
+}

--- a/src/svg/parser.rs
+++ b/src/svg/parser.rs
@@ -88,11 +88,7 @@ fn parse_element(node: &Node<'_, '_>) -> Result<Primitive, ParseError> {
         "text" => Ok(Primitive::Text {
             x: attr_f64(node, "x").unwrap_or(0.0),
             y: attr_f64(node, "y").unwrap_or(0.0),
-            content: node
-                .children()
-                .filter_map(|n| n.text())
-                .collect::<Vec<_>>()
-                .concat(),
+            content: node.children().filter_map(|n| n.text()).collect::<String>(),
             font_family: attr_string(node, "font-family"),
             font_size: attr_f64(node, "font-size"),
             fill: attr_string(node, "fill"),

--- a/src/svg/primitive.rs
+++ b/src/svg/primitive.rs
@@ -1,0 +1,69 @@
+#[derive(Debug, PartialEq)]
+pub enum Primitive {
+    Rect {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        fill: Option<String>,
+        stroke: Option<String>,
+        stroke_width: Option<f64>,
+    },
+    Line {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        stroke: Option<String>,
+        stroke_width: Option<f64>,
+    },
+    Polyline {
+        points: Vec<(f64, f64)>,
+        stroke: Option<String>,
+        stroke_width: Option<f64>,
+    },
+    Path {
+        d: String,
+        fill: Option<String>,
+        stroke: Option<String>,
+        stroke_width: Option<f64>,
+    },
+    Circle {
+        cx: f64,
+        cy: f64,
+        r: f64,
+        fill: Option<String>,
+        stroke: Option<String>,
+        stroke_width: Option<f64>,
+    },
+    Ellipse {
+        cx: f64,
+        cy: f64,
+        rx: f64,
+        ry: f64,
+        fill: Option<String>,
+        stroke: Option<String>,
+        stroke_width: Option<f64>,
+    },
+    Polygon {
+        points: Vec<(f64, f64)>,
+        fill: Option<String>,
+        stroke: Option<String>,
+        stroke_width: Option<f64>,
+    },
+    Text {
+        x: f64,
+        y: f64,
+        content: String,
+        font_family: Option<String>,
+        font_size: Option<f64>,
+        fill: Option<String>,
+    },
+    Group {
+        children: Vec<Primitive>,
+    },
+    Unknown {
+        tag: String,
+        attrs: Vec<(String, String)>,
+    },
+}

--- a/tests/fixtures/simple.svg
+++ b/tests/fixtures/simple.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect x="10" y="10" width="30" height="20" fill="blue" stroke="black" stroke-width="2"/>
+  <text x="50" y="50" font-family="Arial" font-size="12" fill="red">Hello</text>
+  <g>
+    <circle cx="80" cy="80" r="10" fill="green"/>
+  </g>
+</svg>

--- a/tests/svg_parse.rs
+++ b/tests/svg_parse.rs
@@ -1,0 +1,77 @@
+use std::fs;
+
+use blueprinter::svg::{parse_svg, Primitive};
+
+#[test]
+fn test_parse_simple_svg() {
+    let svg = fs::read_to_string("tests/fixtures/simple.svg").unwrap();
+    let primitives = parse_svg(&svg).unwrap();
+
+    assert_eq!(primitives.len(), 3);
+
+    // rect
+    assert_eq!(
+        primitives[0],
+        Primitive::Rect {
+            x: 10.0,
+            y: 10.0,
+            width: 30.0,
+            height: 20.0,
+            fill: Some("blue".to_string()),
+            stroke: Some("black".to_string()),
+            stroke_width: Some(2.0),
+        }
+    );
+
+    // text
+    assert_eq!(
+        primitives[1],
+        Primitive::Text {
+            x: 50.0,
+            y: 50.0,
+            content: "Hello".to_string(),
+            font_family: Some("Arial".to_string()),
+            font_size: Some(12.0),
+            fill: Some("red".to_string()),
+        }
+    );
+
+    // group -> circle
+    match &primitives[2] {
+        Primitive::Group { children } => {
+            assert_eq!(children.len(), 1);
+            assert_eq!(
+                children[0],
+                Primitive::Circle {
+                    cx: 80.0,
+                    cy: 80.0,
+                    r: 10.0,
+                    fill: Some("green".to_string()),
+                    stroke: None,
+                    stroke_width: None,
+                }
+            );
+        }
+        _ => panic!("Expected Group, got {:?}", primitives[2]),
+    }
+}
+
+#[test]
+fn test_unknown_element_passes_through() {
+    let svg = r#"<svg xmlns="http://www.w3.org/2000/svg">
+        <custom-tag foo="bar" baz="123"/>
+    </svg>"#;
+    let primitives = parse_svg(svg).unwrap();
+
+    assert_eq!(primitives.len(), 1);
+    assert_eq!(
+        primitives[0],
+        Primitive::Unknown {
+            tag: "custom-tag".to_string(),
+            attrs: vec![
+                ("foo".to_string(), "bar".to_string()),
+                ("baz".to_string(), "123".to_string()),
+            ],
+        }
+    );
+}


### PR DESCRIPTION
## 関連 Issue
closes #2

## 変更内容
- `roxmltree = "0.20"` を依存関係に追加
- `src/svg/` モジュールを新設:
  - `primitive.rs` — `Primitive` enum（rect, line, polyline, path, circle, ellipse, polygon, text, group, unknown）
  - `parser.rs` — `parse_svg` 関数。SVG を DOM 走査し各要素を `Primitive` に変換
  - `mod.rs` — 公開APIのエクスポート
- `src/lib.rs` を新設し、`pub mod svg;` を公開
- `tests/fixtures/simple.svg` — テスト用簡易SVG
- `tests/svg_parse.rs` — パーステスト

## 受け入れ条件確認
- [x] 任意の SVG ファイルを読み込んで、プリミティブのリストを取得できる
- [x] テスト用の簡易 SVG（rect + text）でパーステストが通る