### PR TITLE
feat: #3 rect/line/path の揺らし変換

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,8 +57,15 @@ name = "blueprinter"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "rand",
  "roxmltree",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -107,6 +114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,10 +137,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -140,6 +173,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -178,6 +241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,4 +259,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.78.0"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 roxmltree = "0.20"
+rand = "0.8"
 
 [dev-dependencies]
 

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -17,6 +17,7 @@ impl Default for JitterConfig {
     }
 }
 
+// TODO: #5 seed 対応で再現性を持たせる
 fn noise(amplitude: f64) -> f64 {
     (random::<f64>() - 0.5) * 2.0 * amplitude
 }

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -1,0 +1,323 @@
+use crate::svg::Primitive;
+use rand::random;
+
+pub struct JitterConfig {
+    pub amplitude: f64,
+    pub frequency: f64,
+    pub stroke_width_var: f64,
+}
+
+impl Default for JitterConfig {
+    fn default() -> Self {
+        Self {
+            amplitude: 2.0,
+            frequency: 5.0,
+            stroke_width_var: 0.2,
+        }
+    }
+}
+
+fn noise(amplitude: f64) -> f64 {
+    (random::<f64>() - 0.5) * 2.0 * amplitude
+}
+
+fn jittered_stroke_width(base: Option<f64>, config: &JitterConfig) -> Option<f64> {
+    base.map(|w| {
+        let v = noise(config.stroke_width_var * w);
+        (w + v).max(0.1)
+    })
+}
+
+fn format_path_element(
+    d: &str,
+    fill: &Option<String>,
+    stroke: &Option<String>,
+    stroke_width: &Option<f64>,
+) -> String {
+    let mut attrs = vec![format!(r#"d="{}""#, d)];
+    if let Some(f) = fill {
+        attrs.push(format!(r#"fill="{}""#, f));
+    }
+    if let Some(s) = stroke {
+        attrs.push(format!(r#"stroke="{}""#, s));
+    }
+    if let Some(sw) = stroke_width {
+        attrs.push(format!(r#"stroke-width="{:.3}""#, sw));
+    }
+    format!("<path {} />", attrs.join(" "))
+}
+
+pub fn jitter_primitive(primitive: &Primitive, config: &JitterConfig) -> String {
+    match primitive {
+        Primitive::Rect {
+            x,
+            y,
+            width,
+            height,
+            fill,
+            stroke,
+            stroke_width,
+        } => {
+            let d = jitter_rect(*x, *y, *width, *height, config);
+            let sw = jittered_stroke_width(*stroke_width, config);
+            format_path_element(&d, fill, stroke, &sw)
+        }
+        Primitive::Line {
+            x1,
+            y1,
+            x2,
+            y2,
+            stroke,
+            stroke_width,
+        } => {
+            let d = jitter_line(*x1, *y1, *x2, *y2, config);
+            let sw = jittered_stroke_width(*stroke_width, config);
+            format_path_element(&d, &None, stroke, &sw)
+        }
+        Primitive::Polyline {
+            points,
+            stroke,
+            stroke_width,
+        } => {
+            let d = jitter_polyline(points, config);
+            let sw = jittered_stroke_width(*stroke_width, config);
+            format_path_element(&d, &None, stroke, &sw)
+        }
+        Primitive::Path {
+            d,
+            fill,
+            stroke,
+            stroke_width,
+        } => {
+            let jd = jitter_path_d(d, config);
+            let sw = jittered_stroke_width(*stroke_width, config);
+            format_path_element(&jd, fill, stroke, &sw)
+        }
+        _ => "<!-- unsupported -->".to_string(),
+    }
+}
+
+fn jitter_rect(x: f64, y: f64, w: f64, h: f64, config: &JitterConfig) -> String {
+    let segments = config.frequency.max(1.0).ceil() as usize;
+    let mut pts = Vec::new();
+
+    // top edge
+    for i in 0..segments {
+        let t = i as f64 / segments as f64;
+        pts.push((
+            x + w * t + noise(config.amplitude),
+            y + noise(config.amplitude),
+        ));
+    }
+    // right edge
+    for i in 1..segments {
+        let t = i as f64 / segments as f64;
+        pts.push((
+            x + w + noise(config.amplitude),
+            y + h * t + noise(config.amplitude),
+        ));
+    }
+    // bottom edge
+    for i in 1..segments {
+        let t = i as f64 / segments as f64;
+        pts.push((
+            x + w * (1.0 - t) + noise(config.amplitude),
+            y + h + noise(config.amplitude),
+        ));
+    }
+    // left edge
+    for i in 1..=segments {
+        let t = i as f64 / segments as f64;
+        pts.push((
+            x + noise(config.amplitude),
+            y + h * (1.0 - t) + noise(config.amplitude),
+        ));
+    }
+
+    if pts.is_empty() {
+        return String::new();
+    }
+    let mut d = format!("M {:.3} {:.3}", pts[0].0, pts[0].1);
+    for p in pts.iter().skip(1) {
+        d.push_str(&format!(" L {:.3} {:.3}", p.0, p.1));
+    }
+    d.push_str(" Z");
+    d
+}
+
+fn jitter_line(x1: f64, y1: f64, x2: f64, y2: f64, config: &JitterConfig) -> String {
+    let segments = config.frequency.max(1.0).ceil() as usize;
+    let dx = x2 - x1;
+    let dy = y2 - y1;
+    let len = (dx * dx + dy * dy).sqrt();
+    let (nx, ny) = if len > 0.0 {
+        (-dy / len, dx / len)
+    } else {
+        (0.0, 0.0)
+    };
+
+    let mut pts = vec![(x1, y1)];
+    for i in 1..segments {
+        let t = i as f64 / segments as f64;
+        let px = x1 + dx * t;
+        let py = y1 + dy * t;
+        let n = noise(config.amplitude);
+        pts.push((px + nx * n, py + ny * n));
+    }
+    pts.push((x2, y2));
+
+    let mut d = format!("M {:.3} {:.3}", pts[0].0, pts[0].1);
+    for p in pts.iter().skip(1) {
+        d.push_str(&format!(" L {:.3} {:.3}", p.0, p.1));
+    }
+    d
+}
+
+fn jitter_polyline(points: &[(f64, f64)], config: &JitterConfig) -> String {
+    if points.len() < 2 {
+        return String::new();
+    }
+    let segments = config.frequency.max(1.0).ceil() as usize;
+    let mut all_pts = Vec::new();
+    all_pts.push(points[0]);
+
+    for window in points.windows(2) {
+        let (x1, y1) = window[0];
+        let (x2, y2) = window[1];
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+        let len = (dx * dx + dy * dy).sqrt();
+        let (nx, ny) = if len > 0.0 {
+            (-dy / len, dx / len)
+        } else {
+            (0.0, 0.0)
+        };
+
+        for i in 1..segments {
+            let t = i as f64 / segments as f64;
+            let px = x1 + dx * t;
+            let py = y1 + dy * t;
+            let n = noise(config.amplitude);
+            all_pts.push((px + nx * n, py + ny * n));
+        }
+        all_pts.push((x2, y2));
+    }
+
+    // 連続する重複点を除去
+    let mut deduped = Vec::new();
+    for &p in &all_pts {
+        if deduped.is_empty() || deduped.last().unwrap() != &p {
+            deduped.push(p);
+        }
+    }
+
+    let mut d = format!("M {:.3} {:.3}", deduped[0].0, deduped[0].1);
+    for p in deduped.iter().skip(1) {
+        d.push_str(&format!(" L {:.3} {:.3}", p.0, p.1));
+    }
+    d
+}
+
+fn tokenize_d(d: &str) -> Vec<String> {
+    let mut normalized = d.replace(',', " ");
+    for cmd in [
+        'M', 'm', 'L', 'l', 'C', 'c', 'Q', 'q', 'Z', 'z', 'H', 'h', 'V', 'v', 'S', 's', 'T', 't',
+        'A', 'a',
+    ] {
+        normalized = normalized.replace(cmd, &format!(" {} ", cmd));
+    }
+    normalized
+        .split_whitespace()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn is_command(token: &str) -> bool {
+    token.len() == 1 && token.chars().next().unwrap().is_alphabetic()
+}
+
+fn jitter_path_d(d: &str, config: &JitterConfig) -> String {
+    let tokens = tokenize_d(d);
+    let mut result = String::new();
+    let mut i = 0;
+    while i < tokens.len() {
+        if is_command(&tokens[i]) {
+            let cmd = tokens[i].chars().next().unwrap();
+            result.push(cmd);
+            i += 1;
+            match cmd.to_ascii_uppercase() {
+                'M' | 'L' | 'T' => {
+                    while i + 2 <= tokens.len() && !is_command(&tokens[i]) {
+                        let x = tokens[i].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                        let y =
+                            tokens[i + 1].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                        result.push_str(&format!(" {:.3} {:.3}", x, y));
+                        i += 2;
+                    }
+                }
+                'C' => {
+                    while i + 6 <= tokens.len() && !is_command(&tokens[i]) {
+                        for _ in 0..3 {
+                            let x =
+                                tokens[i].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                            let y = tokens[i + 1].parse::<f64>().unwrap_or(0.0)
+                                + noise(config.amplitude);
+                            result.push_str(&format!(" {:.3} {:.3}", x, y));
+                            i += 2;
+                        }
+                    }
+                }
+                'Q' | 'S' => {
+                    while i + 4 <= tokens.len() && !is_command(&tokens[i]) {
+                        for _ in 0..2 {
+                            let x =
+                                tokens[i].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                            let y = tokens[i + 1].parse::<f64>().unwrap_or(0.0)
+                                + noise(config.amplitude);
+                            result.push_str(&format!(" {:.3} {:.3}", x, y));
+                            i += 2;
+                        }
+                    }
+                }
+                'H' => {
+                    while i < tokens.len() && !is_command(&tokens[i]) {
+                        let x = tokens[i].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                        result.push_str(&format!(" {:.3}", x));
+                        i += 1;
+                    }
+                }
+                'V' => {
+                    while i < tokens.len() && !is_command(&tokens[i]) {
+                        let y = tokens[i].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                        result.push_str(&format!(" {:.3}", y));
+                        i += 1;
+                    }
+                }
+                'A' => {
+                    while i + 7 <= tokens.len() && !is_command(&tokens[i]) {
+                        let rx = tokens[i].parse::<f64>().unwrap_or(0.0);
+                        let ry = tokens[i + 1].parse::<f64>().unwrap_or(0.0);
+                        let rot = tokens[i + 2].parse::<f64>().unwrap_or(0.0);
+                        let large_arc = tokens[i + 3].parse::<f64>().unwrap_or(0.0);
+                        let sweep = tokens[i + 4].parse::<f64>().unwrap_or(0.0);
+                        let x =
+                            tokens[i + 5].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                        let y =
+                            tokens[i + 6].parse::<f64>().unwrap_or(0.0) + noise(config.amplitude);
+                        result.push_str(&format!(
+                            " {:.3} {:.3} {:.3} {:.0} {:.0} {:.3} {:.3}",
+                            rx, ry, rot, large_arc, sweep, x, y
+                        ));
+                        i += 7;
+                    }
+                }
+                'Z' => {}
+                _ => {}
+            }
+        } else {
+            // コマンドなしに数字が来た場合はスキップ（正規化で起きないはず）
+            i += 1;
+        }
+    }
+    result
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod jitter;
 pub mod svg;

--- a/tests/jitter.rs
+++ b/tests/jitter.rs
@@ -1,0 +1,67 @@
+use blueprinter::jitter::{jitter_primitive, JitterConfig};
+use blueprinter::svg::Primitive;
+
+#[test]
+fn test_jitter_rect_outputs_path() {
+    let rect = Primitive::Rect {
+        x: 10.0,
+        y: 20.0,
+        width: 100.0,
+        height: 50.0,
+        fill: Some("none".to_string()),
+        stroke: Some("black".to_string()),
+        stroke_width: Some(2.0),
+    };
+    let config = JitterConfig::default();
+    let output = jitter_primitive(&rect, &config);
+    assert!(output.starts_with("<path"));
+    assert!(output.contains("d="));
+}
+
+#[test]
+fn test_jitter_line_outputs_path() {
+    let line = Primitive::Line {
+        x1: 0.0,
+        y1: 0.0,
+        x2: 100.0,
+        y2: 100.0,
+        stroke: Some("black".to_string()),
+        stroke_width: Some(1.0),
+    };
+    let config = JitterConfig::default();
+    let output = jitter_primitive(&line, &config);
+    assert!(output.starts_with("<path"));
+    assert!(output.contains("d="));
+}
+
+#[test]
+fn test_jitter_path_changes_d() {
+    let path = Primitive::Path {
+        d: "M 10 10 L 50 50 C 60 60 70 70 80 80 Z".to_string(),
+        fill: None,
+        stroke: Some("red".to_string()),
+        stroke_width: Some(1.5),
+    };
+    let config = JitterConfig::default();
+    let output = jitter_primitive(&path, &config);
+    assert!(output.starts_with("<path"));
+    // 元の d と異なるはず
+    assert!(!output.contains(r#"d="M 10 10 L 50 50 C 60 60 70 70 80 80 Z""#));
+}
+
+#[test]
+fn test_jitter_randomness() {
+    let rect = Primitive::Rect {
+        x: 0.0,
+        y: 0.0,
+        width: 10.0,
+        height: 10.0,
+        fill: None,
+        stroke: Some("black".to_string()),
+        stroke_width: None,
+    };
+    let config = JitterConfig::default();
+    let out1 = jitter_primitive(&rect, &config);
+    let out2 = jitter_primitive(&rect, &config);
+    assert_ne!(out1, out2, "jitter output should be random");
+}


### PR DESCRIPTION
## 関連 Issue
closes #3

## 変更内容
- `rand = "0.8"` を依存関係に追加
- `src/jitter.rs` モジュールを新設:
  - `JitterConfig` 構造体（amplitude, frequency, stroke_width_var）
  - `jitter_primitive` 関数で `Rect`/`Line`/`Polyline`/`Path` を揺らした `<path/>` に変換
  - rect → 4辺を分割し各点にノイズを加えた閉じた path
  - line → 始点〜終点を分割し中間点に垂直方向ノイズ
  - path → `d` 属性を簡易トークナイズし、座標点にノイズを重畳して再構成
  - seed 対応は #5 で統合（TODO コメント付記）
- `src/lib.rs` に `pub mod jitter;` を追加
- `tests/jitter.rs` — 揺らし変換の統合テスト

## 受け入れ条件確認
- [x] 入力 rect → 揺れた path の出力が確認できる
- [x] line → 揺れた path の出力が確認できる
- [x] path → 制御点がずれた path の出力が確認できる
- [ ] 同じ seed を与えると同じ出力になる → #5 で対応