### PR TITLE
feat: add Mermaid PoC workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Turn SVG into sketchy SVG today. Mermaid, draw.io direct input, and raster expor
 ## Installation
 
 ```bash
-cargo install blueprinter
+cargo install --git https://github.com/kako-jun/blueprinter blueprinter
 ```
+
+`blueprinter` is not published to crates.io yet.
 
 ## Usage
 
@@ -16,6 +18,19 @@ cargo install blueprinter
 # Transform an existing SVG with the default blueprint theme
 blueprinter transform -i input.svg -o output.svg --theme blueprint --seed 42
 ```
+
+## Mermaid PoC
+
+If you want to evaluate whether blueprinter is visually compelling on real
+diagram shapes today, run the Mermaid proof-of-concept workflow:
+
+```bash
+scripts/mermaid-poc.sh
+```
+
+This renders a small Mermaid fixture set to baseline SVG, then runs
+`blueprinter transform` so you can compare baseline vs stylized output side by
+side. See [docs/poc.md](docs/poc.md) for details.
 
 ## Themes
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 # blueprinter Overview
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
 ## What is blueprinter?
 
@@ -45,6 +45,11 @@ definition containers such as `defs`, `symbol`, and `marker` are intentionally
 left unchanged; shapes referenced via `use` therefore remain as authored until
 symbol-level styling is implemented.
 
+For current confidence-building, the repository includes a Mermaid proof of
+concept workflow that generates representative diagrams via `mmdc` and then
+runs `blueprinter transform` on the resulting SVG. This is intentionally
+separate from full Mermaid direct-input support.
+
 ### Randomness with Reproducibility
 
 Hand-drawn style requires variation. Every run produces a slightly different result.
@@ -74,13 +79,9 @@ Input SVG
     │    ├── Color palette swap (theme)
     │    └── Random offset / jitter
     ▼
-Intermediate SVG
-    │
-    ▼
-[ Rasterizer (resvg, planned) ]  ──optional──►  PNG / WebP
-    │
-    ▼
 Output SVG
+    │
+    └── optional raster export (planned via resvg) ──► PNG / WebP
 ```
 
 ## Themes
@@ -100,4 +101,4 @@ Output SVG
 - **clap** — CLI argument parsing and subcommands
 - **SVG parsing** — roxmltree or similar for SVG DOM manipulation
 - **resvg** — planned SVG rasterization for PNG/WebP output
-- **mmdc** — planned external Mermaid CLI for Mermaid → SVG conversion
+- **mmdc** — already usable as a PoC dependency for Mermaid → SVG fixture generation; direct Mermaid input support inside blueprinter is still planned

--- a/docs/poc.md
+++ b/docs/poc.md
@@ -1,0 +1,85 @@
+# blueprinter Mermaid PoC
+
+This document exists to answer one question before deeper feature work:
+
+**Can blueprinter make Mermaid-generated diagrams look attractive enough to be worth pursuing?**
+
+The PoC deliberately avoids implementing full Mermaid direct-input support.
+Instead, it gives us a repeatable visual workflow for producing baseline SVGs
+with Mermaid CLI and then running `blueprinter transform` on top.
+
+`mmdc` is therefore a **workflow dependency for this PoC today**, even though
+Mermaid direct-input support inside the CLI remains a planned feature.
+
+## Included Fixtures
+
+- `tests/fixtures/mermaid/flowchart.mmd`
+- `tests/fixtures/mermaid/sequence.mmd`
+- `tests/fixtures/mermaid/er-diagram.mmd`
+
+These three fixture types were chosen because they stress different failure
+modes:
+
+- **Flowchart**: box + arrow charm. Good for checking whether wobble adds warmth.
+- **Sequence diagram**: many parallel lines. Good for checking whether jitter turns into clutter.
+- **ER diagram**: node/edge density + labels. Good for checking structural readability.
+
+## Run the PoC
+
+Prerequisites:
+
+- `mmdc` must be available on `PATH`
+- Rust toolchain installed
+
+Run:
+
+```bash
+scripts/mermaid-poc.sh
+```
+
+Outputs are written to:
+
+```text
+target/poc/
+├── baseline/
+│   ├── er-diagram.svg
+│   ├── flowchart.svg
+│   └── sequence.svg
+└── blueprinter/
+    ├── er-diagram.svg
+    ├── flowchart.svg
+    └── sequence.svg
+```
+
+You can override the output directory:
+
+```bash
+scripts/mermaid-poc.sh /tmp/blueprinter-poc
+```
+
+You can also override the seed:
+
+```bash
+BLUEPRINTER_POC_SEED=7 scripts/mermaid-poc.sh
+```
+
+## What to Look For
+
+When comparing baseline vs transformed SVG, evaluate these points:
+
+1. **Charm**: does the transformed version feel more human or handcrafted?
+2. **Legibility**: are labels, arrows, and node boundaries still easy to read?
+3. **Density tolerance**: which diagram types get better, and which get muddy?
+4. **Theme confidence**: is the current blueprint treatment interesting enough to justify more theme investment?
+
+## Expected Outcome
+
+The goal is not for every diagram type to look perfect.
+The goal is to identify:
+
+- which Mermaid diagrams already look promising with current jitter
+- where blueprint styling is too weak
+- whether theme work should proceed before Mermaid direct input
+
+If the transformed outputs do not look compelling, we should improve visual
+treatment before spending much more effort on additional format support.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # blueprinter ロードマップ
 
-最終更新: 2026-04-23
+最終更新: 2026-04-24
 
 ## 完了済み
 
@@ -39,6 +39,13 @@
 - [x] 線の太さ揺れ
 - [x] transform CLI から SVG 入力 → SVG 出力まで接続
 - [x] `--seed` による transform 出力の再現性
+
+### Phase 2.5: Mermaid見た目PoC（#20）
+
+- [x] Mermaid fixture 3本（flowchart / sequence / ER）追加
+- [x] `mmdc` → baseline SVG → `blueprinter transform` の PoC スクリプト追加
+- [x] baseline / transformed の見比べ手順を docs 化
+- [x] fixtures / script / docs の整合を守る軽量テスト追加
 
 ## 残タスク
 

--- a/scripts/mermaid-poc.sh
+++ b/scripts/mermaid-poc.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixtures_dir="$repo_root/tests/fixtures/mermaid"
+output_root="${1:-$repo_root/target/poc}"
+seed="${BLUEPRINTER_POC_SEED:-42}"
+
+baseline_dir="$output_root/baseline"
+transformed_dir="$output_root/blueprinter"
+
+mkdir -p "$baseline_dir" "$transformed_dir"
+
+run_mmdc() {
+  env -u NODE_OPTIONS mmdc "$@"
+}
+
+echo "Generating Mermaid PoC outputs..."
+echo "  fixtures: $fixtures_dir"
+echo "  output:   $output_root"
+echo "  seed:     $seed"
+
+for fixture in "$fixtures_dir"/*.mmd; do
+  name="$(basename "$fixture" .mmd)"
+  baseline_svg="$baseline_dir/$name.svg"
+  transformed_svg="$transformed_dir/$name.svg"
+
+  echo
+  echo "[$name] Mermaid -> SVG"
+  run_mmdc -i "$fixture" -o "$baseline_svg" -b transparent
+
+  echo "[$name] SVG -> blueprinter"
+  cargo run --manifest-path "$repo_root/Cargo.toml" -- \
+    transform \
+    --input "$baseline_svg" \
+    --output "$transformed_svg" \
+    --theme blueprint \
+    --seed "$seed"
+done
+
+cat <<EOF
+
+PoC generation complete.
+
+Compare these pairs side by side:
+  baseline:    $baseline_dir/*.svg
+  transformed: $transformed_dir/*.svg
+
+Evaluation prompts:
+  - Does the transformed version feel more human without losing legibility?
+  - Which diagram type benefits most from jitter?
+  - Where do labels, arrows, or dense edges become noisy instead of charming?
+  - Is blueprint already interesting enough to justify deeper theme work?
+EOF

--- a/tests/fixtures/mermaid/er-diagram.mmd
+++ b/tests/fixtures/mermaid/er-diagram.mmd
@@ -1,0 +1,31 @@
+erDiagram
+    ARTICLE ||--o{ DIAGRAM : contains
+    DIAGRAM ||--|{ NODE : includes
+    DIAGRAM ||--|{ EDGE : includes
+    THEME ||--o{ DIAGRAM : styles
+    REVIEW ||--|| DIAGRAM : evaluates
+
+    ARTICLE {
+        string slug
+        string title
+    }
+    DIAGRAM {
+        string format
+        string source
+    }
+    NODE {
+        string label
+        string shape
+    }
+    EDGE {
+        string kind
+        string direction
+    }
+    THEME {
+        string name
+        string palette
+    }
+    REVIEW {
+        bool readable
+        bool charming
+    }

--- a/tests/fixtures/mermaid/flowchart.mmd
+++ b/tests/fixtures/mermaid/flowchart.mmd
@@ -1,0 +1,8 @@
+flowchart TD
+    user([User]) --> upload[Upload diagram source]
+    upload --> render[Render with Mermaid]
+    render --> transform[blueprinter transform]
+    transform --> review{Looks charming?}
+    review -->|yes| publish[Ship the aesthetic]
+    review -->|no| tweak[Tune jitter and themes]
+    tweak --> transform

--- a/tests/fixtures/mermaid/sequence.mmd
+++ b/tests/fixtures/mermaid/sequence.mmd
@@ -1,0 +1,11 @@
+sequenceDiagram
+    participant A as Agent
+    participant B as blueprinter
+    participant R as Reviewer
+
+    A->>B: transform diagram.svg
+    B-->>A: sketchy svg
+    A->>R: compare baseline vs transformed
+    R-->>A: too noisy around labels
+    A->>B: tune config / theme
+    B-->>A: second pass

--- a/tests/poc_assets.rs
+++ b/tests/poc_assets.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn mermaid_poc_assets_and_docs_stay_in_sync() {
+    let fixture_paths = [
+        "tests/fixtures/mermaid/flowchart.mmd",
+        "tests/fixtures/mermaid/sequence.mmd",
+        "tests/fixtures/mermaid/er-diagram.mmd",
+    ];
+    for path in fixture_paths {
+        assert!(Path::new(path).exists(), "missing fixture: {path}");
+    }
+
+    assert!(
+        Path::new("scripts/mermaid-poc.sh").exists(),
+        "missing PoC script"
+    );
+
+    let readme = fs::read_to_string("README.md").expect("read README.md");
+    assert!(readme.contains("scripts/mermaid-poc.sh"));
+
+    let poc_doc = fs::read_to_string("docs/poc.md").expect("read docs/poc.md");
+    assert!(poc_doc.contains("tests/fixtures/mermaid/flowchart.mmd"));
+    assert!(poc_doc.contains("tests/fixtures/mermaid/sequence.mmd"));
+    assert!(poc_doc.contains("tests/fixtures/mermaid/er-diagram.mmd"));
+    assert!(poc_doc.contains("scripts/mermaid-poc.sh"));
+
+    let roadmap = fs::read_to_string("docs/roadmap.md").expect("read docs/roadmap.md");
+    assert!(roadmap.contains("Phase 2.5: Mermaid見た目PoC（#20）"));
+}


### PR DESCRIPTION
## Related Issue
closes #20

## Summary
- add Mermaid fixtures for flowchart, sequence, and ER diagrams
- add a Mermaid PoC script that generates baseline SVG and blueprinter-transformed SVG
- document how to evaluate the PoC and add a lightweight sync test for fixtures/docs/script
