### PR TITLE
feat: output デフォルトを PNG に切り替え、SVG は debug-only に格下げ (#31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # blueprinter - Hand-drawn Style Diagram Renderer
 
-図の手書き風レンダラー CLI。現状は任意の SVG を手書き風 SVG に変換する。Mermaid / draw.io 直接入力、PNG/WebP 出力は予定。
+図の手書き風レンダラー CLI。最終出力はラスター画像（PNG / WebP）。入力は SVG / Mermaid (mmdc 経由) / Markdown 埋め込みブロックで、draw.io 直接入力は予定。SVG 出力モードはパイプライン途中の中間 SVG をダンプする debug-only 用途として残してある。
 
 ## ドキュメント
 
@@ -37,7 +37,7 @@ src/
 ## 主要な設計判断
 
 - **レイアウト計算はしない** — 入力 SVG の座標をそのまま使い、見た目（stroke, fill, filter）のみを変換する
-- **SVG→SVG が核** — 現状の実装対象。フォーマット変換（PNG/WebP）は resvg による後工程として予定
+- **ラスター主軸** — ユーザー向けの最終出力は PNG / WebP。内部的には styled SVG を中間表現として作り resvg でラスタライズする。中間 SVG は `--format svg` または `.svg` 出力パスでダンプ可能だが debug-only 扱いで、aquarelle (#25) や text path 化 (#4) のような SVG では表現しきれない加工を今後追加していく前提
 - **毎回違う出力** — 手書き風のランダム性を持たせる。`--seed` で再現可能（transform 実装済み）
 - **エディタは作らない** — CLI で変換するだけ。入力は既存のエディタ・ツールで作成する
 - **mmdc 連携** — Mermaid 入力対応時は mermaid-cli（mmdc）を外部コマンドとして呼び出す予定

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hand-drawn style embedded-visual renderer CLI.
 
-Turn SVG into sketchy SVG today. Rasterize to PNG / WebP. Mermaid input is supported via the external `mmdc` (mermaid-cli). The Markdown pipeline currently batch-renders embedded `mermaid` blocks and is planned to expand into a general embedded-visual compiler, starting with `latex-render` blocks for editorial cards, lists, and tables. draw.io direct input is planned.
+blueprinter renders structured diagrams (Mermaid today via the external `mmdc`, draw.io direct input planned) as hand-drawn raster images. The primary outputs are **PNG** and **WebP**; SVG output is kept as a debug-only intermediate so you can inspect the styling pipeline before rasterization. The Markdown pipeline currently batch-renders embedded `mermaid` blocks and is planned to expand into a general embedded-visual compiler, starting with `latex-render` blocks for editorial cards, lists, and tables.
 
 ## Installation
 
@@ -15,42 +15,48 @@ Or download a prebuilt binary from GitHub Releases once `v0.1.0+` tags are publi
 ## Usage
 
 ```bash
-# Render a Mermaid diagram (requires mmdc on PATH)
-blueprinter render -i flowchart.mmd -o flowchart.svg --theme manga --seed 42
+# Render a Mermaid diagram to PNG (requires mmdc on PATH)
+blueprinter render -i flowchart.mmd -o flowchart.png --theme manga --seed 42
 
 # Batch-render every supported embedded visual block in a Markdown file
-blueprinter md -i README.md -o ./diagrams --theme manga --format png --width 800
+# (PNG is the default format)
+blueprinter md -i README.md -o ./diagrams --theme manga --width 800
 
-# Transform an existing SVG with the default blueprint theme
-blueprinter transform -i input.svg -o output.svg --theme blueprint --seed 42
+# Transform an existing SVG into a hand-drawn PNG
+blueprinter transform -i input.svg -o output.png --theme blueprint --seed 42
+
+# Export to PNG with an explicit scale factor
+blueprinter transform -i input.svg -o output.png \
+  --scale 2.0
+
+# Export to PNG with explicit dimensions (maintains aspect ratio)
+blueprinter transform -i input.svg -o output.png \
+  --width 800
+
+# Export to lossless WebP (smaller than PNG for diagram content)
+blueprinter transform -i input.svg -o output.webp \
+  --width 800
 
 # Tune the hand-drawn intensity
-blueprinter transform -i input.svg -o output.svg \
+blueprinter transform -i input.svg -o output.png \
   --seed 42 \
   --jitter-amplitude 3.5 \
   --jitter-frequency 7 \
   --jitter-stroke-width-var 0.4
 
 # Override text font-family while keeping layout intact
-blueprinter transform -i input.svg -o output.svg \
+blueprinter transform -i input.svg -o output.png \
   --seed 42 \
   --font-family "Virgil"
 
-# Export to PNG (2x scale)
-blueprinter transform -i input.svg -o output.png \
-  --format png \
-  --scale 2.0
-
-# Export to PNG with explicit dimensions (maintains aspect ratio)
-blueprinter transform -i input.svg -o output.png \
-  --format png \
-  --width 800
-
-# Export to lossless WebP (smaller than PNG for diagram content)
-blueprinter transform -i input.svg -o output.webp \
-  --format webp \
-  --width 800
+# Debug-only: dump the intermediate styled SVG before rasterization
+blueprinter transform -i input.svg -o debug.svg --format svg --seed 42
 ```
+
+> Note: `--format svg` (and writing to a `.svg` path) keeps working, but SVG
+> output is treated as a debug aid — the styling pipeline is moving toward
+> raster-only effects (watercolor bleed, text-to-path, etc.) that cannot be
+> faithfully represented in SVG.
 
 `--jitter-amplitude` controls how far coordinates can wobble, `--jitter-frequency`
 controls how densely strokes are subdivided before wobble is applied, and
@@ -72,7 +78,7 @@ if omitted, existing text fonts and stylesheet-driven fonts are left as authored
 The sumi (墨) theme mimics traditional Japanese ink painting with grayscale strokes and a soft bleed effect.
 
 ```bash
-blueprinter transform -i input.svg -o output.svg --theme sumi --seed 42
+blueprinter transform -i input.svg -o output.png --theme sumi --seed 42
 ```
 
 **Features:**
@@ -85,7 +91,7 @@ blueprinter transform -i input.svg -o output.svg --theme sumi --seed 42
 The watercolor theme simulates soft pigment mixing and color bleeding with pastel colors.
 
 ```bash
-blueprinter transform -i input.svg -o output.svg --theme watercolor --seed 42
+blueprinter transform -i input.svg -o output.png --theme watercolor --seed 42
 ```
 
 **Features:**
@@ -99,7 +105,7 @@ blueprinter transform -i input.svg -o output.svg --theme watercolor --seed 42
 The manga theme renders crisp black ink lines on white paper, with closed shapes filled by `<pattern>`-based screentones (sparse dots, dense dots, or diagonal lines) sampled per shape.
 
 ```bash
-blueprinter transform -i input.svg -o output.svg --theme manga --seed 42
+blueprinter transform -i input.svg -o output.png --theme manga --seed 42
 ```
 
 **Features:**
@@ -113,7 +119,7 @@ blueprinter transform -i input.svg -o output.svg --theme manga --seed 42
 The marker theme renders strokes in saturated neon highlighter colors on a dark navy background, with a soft halo behind each shape.
 
 ```bash
-blueprinter transform -i input.svg -o output.svg --theme marker --seed 42
+blueprinter transform -i input.svg -o output.png --theme marker --seed 42
 ```
 
 **Features:**
@@ -128,7 +134,7 @@ blueprinter transform -i input.svg -o output.svg --theme marker --seed 42
 The chalk theme renders strokes as white (and occasional pale color) chalk on a slate-green chalkboard, with a dust filter that breaks each stroke up.
 
 ```bash
-blueprinter transform -i input.svg -o output.svg --theme chalk --seed 42
+blueprinter transform -i input.svg -o output.png --theme chalk --seed 42
 ```
 
 **Features:**
@@ -141,9 +147,9 @@ blueprinter transform -i input.svg -o output.svg --theme chalk --seed 42
 ## Current Status
 
 ### Implemented
-- `transform` command: SVG → hand-drawn SVG transformation
-- PNG output: `--format png`, with `--scale`, `--width`, `--height` options
-- WebP output: `--format webp` (lossless; same flags as PNG)
+- `transform` command: SVG → hand-drawn raster (PNG/WebP) — SVG-output mode is preserved as a debug aid
+- PNG output (default): `--scale`, `--width`, `--height` options
+- WebP output (lossless): same flags as PNG, via `--format webp` or a `.webp` output path
 - `render` command: Mermaid (`.mmd` / `.mermaid`) → mmdc → blueprinter pipeline. Supports the same theme / output-format / jitter / font flags as `transform`. Requires [mermaid-cli](https://github.com/mermaid-js/mermaid-cli): `npm install -g @mermaid-js/mermaid-cli`
 - `md` command: currently extracts every ` ```mermaid ` block from a Markdown file and writes them to an output directory as `<stem>-<n>.<ext>`. This command is intended to grow into the general pipeline for embedded visual blocks such as future `latex-render`.
 - Blueprint theme: complete with stroke/fill styling and background
@@ -189,7 +195,7 @@ blueprinter transform -i input.svg -o output.png --format png \
 The repo-level `fonts/` directory is reserved for future built-in bundling; see `fonts/README.md` for license-compatible OFL fonts that fit each theme.
 
 ### Known Limitations
-- XML declarations, comments, processing instructions, doctypes, and CDATA boundaries are not preserved
+- The debug-only SVG output does not preserve XML declarations, comments, processing instructions, doctypes, or CDATA boundaries
 - Symbols and definitions under `defs`/`symbol`/`marker` are preserved without jitter
 
 ## License

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ When rasterizing to PNG / WebP, blueprinter loads the host's system fonts so any
 For cross-platform reproducibility, pass `--font-dir <path>` to load every `.ttf` / `.otf` in a directory into the rasterizer's font database. This is the recommended way to pin specific fonts:
 
 ```bash
-blueprinter transform -i input.svg -o output.png --format png \
+blueprinter transform -i input.svg -o output.png \
   --font-dir ./fonts \
   --font-family "Caveat"
 ```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,16 +1,19 @@
 # blueprinter Overview
 
-Last updated: 2026-04-27
+Last updated: 2026-05-18
 
 ## What is blueprinter?
 
 **blueprinter** is a CLI tool for turning embedded visuals into a hand-drawn, sketchy style.
 It accepts arbitrary SVG via `transform`, Mermaid (through external `mmdc`) via `render`,
 and Markdown documents containing one or more supported embedded visual blocks via `md`,
-and produces stylized SVG, PNG, or WebP output. Today the Markdown path handles `mermaid`
-blocks; the next planned expansion is `latex-render` blocks so lists, tables, and editorial
-layouts can be authored beside Markdown and rendered as static visual cards. draw.io direct
-input is a planned follow-up phase.
+and produces stylized **PNG or WebP** output by default. Stylized SVG output is still
+supported, but it is treated as a debug intermediate — the styling pipeline is being
+re-centred on raster effects (watercolor bleed, text-as-path, etc.) that cannot be
+faithfully expressed in SVG. Today the Markdown path handles `mermaid` blocks; the next
+planned expansion is `latex-render` blocks so lists, tables, and editorial layouts can be
+authored beside Markdown and rendered as static visual cards. draw.io direct input is a
+planned follow-up phase.
 
 The core idea: **do not recompute layout unless a front-end format requires it**.
 When blueprinter receives SVG, it preserves the existing geometry and transforms
@@ -43,19 +46,24 @@ any SVG-producing tool can be a front-end. For higher-level embedded formats suc
 as Mermaid or planned `latex-render`, layout belongs to the upstream compiler, not
 to blueprinter's styling stage.
 
-### SVG-first Pipeline
+### Raster-first Pipeline
 
-The internal pipeline is SVG → SVG first.
-PNG and WebP export are planned later, and will rasterize from the transformed SVG.
-This preserves vector quality for downstream editing and makes the transformation
-inspectable and debuggable.
+The user-facing pipeline is **structured-input → styled raster (PNG / WebP)**.
+Internally we still build a styled SVG as the intermediate representation, then
+rasterize it with `resvg`; that intermediate can be dumped to disk for inspection
+via `--format svg` (or by writing to a `.svg` path), but it is no longer the
+default output. Treating raster as the primary product lets future stages add
+effects that have no faithful SVG equivalent — watercolor bleed (#25), text
+converted to path (#4), and similar — without breaking a "SVG round-trip"
+contract that blueprinter was never trying to keep.
 
-The current serializer preserves non-jittered element structure, attributes,
-namespaces, and text, but it does not preserve XML declarations, comments,
-processing instructions, doctypes, or CDATA boundaries yet. Non-visual
-definition containers such as `defs`, `symbol`, and `marker` are intentionally
-left unchanged; shapes referenced via `use` therefore remain as authored until
-symbol-level styling is implemented.
+The intermediate SVG serializer preserves non-jittered element structure,
+attributes, namespaces, and text, but it does not preserve XML declarations,
+comments, processing instructions, doctypes, or CDATA boundaries; this is fine
+because that artifact is debug-only. Non-visual definition containers such as
+`defs`, `symbol`, and `marker` are intentionally left unchanged; shapes
+referenced via `use` therefore remain as authored until symbol-level styling
+is implemented.
 
 ### Randomness with Reproducibility
 
@@ -93,17 +101,17 @@ Input format
                           Intermediate SVG
     │
     ▼
-[ Layout-preserving SVG filter ]
+[ Layout-preserving styling stage ]
     │    ├── Stroke wobble
     │    ├── Fill texture
     │    ├── Color palette swap (theme)
     │    └── Random offset / jitter
     ▼
-Intermediate SVG
+Styled intermediate SVG
     │
-    ├──► Output SVG
+    ├──► [ Rasterizer (resvg) ]  ──►  PNG / WebP   (default output)
     │
-    └──► [ Rasterizer (resvg) ]  ──optional──►  PNG / WebP (lossless)
+    └──► debug-only SVG dump      (--format svg / *.svg path)
 ```
 
 For Markdown input, `md` acts as an orchestrator: find supported fenced blocks,
@@ -127,5 +135,5 @@ replaced by image references.
 - **Rust** — CLI and pipeline
 - **clap** — CLI argument parsing and subcommands
 - **SVG parsing** — roxmltree or similar for SVG DOM manipulation
-- **resvg** — planned SVG rasterization for PNG/WebP output
+- **resvg** — SVG rasterization for PNG/WebP output (default path)
 - **mmdc** — external Mermaid CLI invoked by the `render` subcommand for Mermaid → SVG conversion

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # blueprinter ロードマップ
 
-最終更新: 2026-04-25
+最終更新: 2026-05-18
 
 ## 完了済み
 
@@ -73,6 +73,7 @@
 - [x] md 一括変換モード — `md` サブコマンドが `.md` から ` ```mermaid ` ブロックを抽出 (line-by-line state machine、依存追加なし) し、`<out_dir>/<stem>-<n>.<ext>` で連番出力
 - [x] PNG 出力（resvg 導入、#11 完了）— `--format png`, `--scale`, `--width`, `--height` 対応
 - [x] WebP 出力（lossless）— `webp` クレート導入、PNG と同じフラグで動作。Diagram 用途では PNG より大幅に小さくなる
+- [x] 出力デフォルトをラスター主軸へ切替（#31）— `transform` / `render` の拡張子推定既定を `png` に、`md` サブコマンドの `--format` 既定も `png` に変更。SVG 出力は `--format svg` または `.svg` 拡張子で引き続き利用可能だが debug-only 扱い
 
 ### Phase 6: 追加テーマ・図形（#13, #14）
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use blueprinter::svg::{export_to_png, export_to_webp, transform_svg, Theme, Tran
 #[command(version)]
 #[command(about = "Hand-drawn style diagram renderer CLI")]
 #[command(
-    long_about = "Turn SVG into sketchy SVG. Mermaid via mmdc and draw.io direct input are planned."
+    long_about = "Render structured diagrams (Mermaid, draw.io-planned) as hand-drawn raster images. \
+PNG/WebP are the primary outputs; SVG output remains available for debugging the pipeline."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -59,7 +60,9 @@ struct OutputArgs {
     #[arg(short, long)]
     output: String,
 
-    /// Output format (svg, png, webp). Inferred from output extension if omitted.
+    /// Output format (png, webp, svg). Inferred from output extension if
+    /// omitted; defaults to png when the extension is unrecognised. svg is
+    /// debug-only.
     #[arg(long)]
     format: Option<String>,
 
@@ -126,8 +129,8 @@ enum Commands {
         #[command(flatten)]
         style: StyleArgs,
 
-        /// Output format (svg, png, webp). Default: svg.
-        #[arg(long, default_value = "svg")]
+        /// Output format (png, webp, svg). Default: png. svg is debug-only.
+        #[arg(long, default_value = "png")]
         format: String,
 
         /// Scale factor for raster output (default: 1.0)
@@ -382,7 +385,7 @@ fn infer_format_from_path(path: &str) -> &'static str {
         Some("png") => "png",
         Some("webp") => "webp",
         Some("svg") => "svg",
-        _ => "svg",
+        _ => "png",
     }
 }
 
@@ -525,7 +528,7 @@ mod tests {
 
     #[test]
     fn infer_format_from_path_default() {
-        assert_eq!(infer_format_from_path("output.txt"), "svg");
+        assert_eq!(infer_format_from_path("output.txt"), "png");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,7 +225,7 @@ fn run_md_batch(
     let ext = match format {
         "svg" | "png" | "webp" => format,
         _ => {
-            eprintln!("Error: unknown format '{format}'. Supported: svg, png, webp.");
+            eprintln!("Error: unknown format '{format}'. Supported: png, webp, svg.");
             std::process::exit(1);
         }
     };
@@ -331,7 +331,7 @@ fn run_pipeline(svg: &str, input_label: &str, style: &StyleArgs, out: &OutputArg
         )
         .and_then(|bytes| fs::write(&out.output, bytes).map_err(|e| e.to_string())),
         _ => {
-            eprintln!("Error: unknown format '{output_format}'. Supported: svg, png, webp.");
+            eprintln!("Error: unknown format '{output_format}'. Supported: png, webp, svg.");
             std::process::exit(1);
         }
     };
@@ -527,7 +527,7 @@ mod tests {
     }
 
     #[test]
-    fn infer_format_from_path_default() {
+    fn infer_format_from_path_unknown_extension_falls_back_to_png() {
         assert_eq!(infer_format_from_path("output.txt"), "png");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,4 +553,70 @@ mod tests {
     fn build_dimensions_none() {
         assert_eq!(build_dimensions(None, None), None);
     }
+
+    #[test]
+    fn infer_format_from_path_no_extension_falls_back_to_png() {
+        assert_eq!(infer_format_from_path("output"), "png");
+    }
+
+    #[test]
+    fn infer_format_from_path_trailing_dot_falls_back_to_png() {
+        assert_eq!(infer_format_from_path("output."), "png");
+    }
+
+    #[test]
+    fn infer_format_from_path_uppercase_png_falls_back_to_png() {
+        assert_eq!(infer_format_from_path("OUTPUT.PNG"), "png");
+    }
+
+    #[test]
+    fn infer_format_from_path_uppercase_svg_falls_back_to_png_not_svg() {
+        assert_eq!(infer_format_from_path("OUTPUT.SVG"), "png");
+    }
+
+    #[test]
+    fn md_cli_format_defaults_to_png() {
+        let cli =
+            Cli::try_parse_from(["blueprinter", "md", "-i", "in.md", "-o", "out_dir"]).unwrap();
+        let Commands::Md { format, .. } = cli.command else {
+            panic!("expected md command");
+        };
+        assert_eq!(format, "png");
+    }
+
+    #[test]
+    fn md_cli_format_explicit_svg_preserved() {
+        let cli = Cli::try_parse_from([
+            "blueprinter",
+            "md",
+            "-i",
+            "in.md",
+            "-o",
+            "out_dir",
+            "--format",
+            "svg",
+        ])
+        .unwrap();
+        let Commands::Md { format, .. } = cli.command else {
+            panic!("expected md command");
+        };
+        assert_eq!(format, "svg");
+    }
+
+    #[test]
+    fn transform_cli_format_explicit_svg_preserved() {
+        let cli = Cli::try_parse_from([
+            "blueprinter",
+            "transform",
+            "-i",
+            "in.svg",
+            "-o",
+            "out.png",
+            "--format",
+            "svg",
+        ])
+        .unwrap();
+        let (_, output_args) = assert_transform_command(cli);
+        assert_eq!(output_args.format.as_deref(), Some("svg"));
+    }
 }


### PR DESCRIPTION
## 関連 Issue

closes #31

## 変更内容

blueprinter の最終出力はラスター画像（PNG / WebP）。中間 SVG は debug 用途のみとして残すパイプラインに揃えるための土台 PR。後続 #25 (aquarelle) / #4 (text path 化) の前提になる。

### コード

- `src/main.rs::infer_format_from_path`: 拡張子不明時のフォールバックを `"svg"` → `"png"`
- `src/main.rs::Commands::Md` の `--format`: `default_value = "svg"` → `"png"`
- `OutputArgs.format` の doc コメントと `long_about` 文言をラスター主軸に書き換え

### docs

- README.md: 冒頭説明・例の優先順を PNG/WebP 主軸に再編、SVG 出力は debug-only と明記
- docs/overview.md: "SVG-first Pipeline" → "Raster-first Pipeline"、パイプライン図を更新
- docs/roadmap.md: Phase 5 に「出力デフォルトをラスター主軸へ切替（#31）」追記
- CLAUDE.md: 「SVG→SVG が核」をラスター主軸に書き換え

### test

`src/main.rs::mod tests` に 7 件追加:

| 観点 | テスト |
|---|---|
| 拡張子なし | `infer_format_from_path_no_extension_falls_back_to_png` |
| 末尾ドット | `infer_format_from_path_trailing_dot_falls_back_to_png` |
| 大文字 PNG | `infer_format_from_path_uppercase_png_falls_back_to_png` |
| 大文字 SVG（事故パターン） | `infer_format_from_path_uppercase_svg_falls_back_to_png_not_svg` |
| Md format デフォルト | `md_cli_format_defaults_to_png` |
| Md format 明示 svg | `md_cli_format_explicit_svg_preserved` |
| Transform --format svg 明示 | `transform_cli_format_explicit_svg_preserved` |

## 非破壊性

- `--format svg` は引き続き動く（debug-only）
- `.svg` 拡張子で出力すれば SVG が出る（拡張子 infer は維持）
- 明示的に SVG を指定していたユーザーは何も壊れない

## スコープ外（後続 Issue）

- aquarelle 接続 (#25)
- text path 化 (#4)
- SVG-filter 仮実装の削除 (#25 / #4)

## 検証

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` 全部 pass (lib 30 / bin 19 / integration 7 / doc 0)
